### PR TITLE
add timeout config

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,9 @@ Configuration
 'ember-cli-memory-leak-detector': {
   enabled: process.env.DETECT_MEMORY_LEAKS || false,
   failTests: false,
-  remoteDebuggingPort: '9222',
   ignoreClasses: ['ExpectedLeakyClass'],
+  remoteDebuggingPort: '9222',
+  timeout: 90000,
   writeSnapshot: true
 }
 
@@ -114,16 +115,20 @@ Configuration
 1. `enabled` (default `true`)
 Set to false to disables memory leak detection. Consider using an environment variable (`process.env.DETECT_MEMORY_LEAKS`) to control when memory leak detection is run.
 
-2. `failTests`: (default `true`)
+1. `failTests`: (default `true`)
 By default when a leak is detected we add a failed test. Set this to `false` to prevent memory leaks from causing your tests to fail, and instead log a console warning.
 
-3. `remoteDebuggingPort`: (default `9222`)
-Configures which port to connect to the testem Chrome instance. This value must match the `--remote-debugging-port` flag set in your app's `testem.js`
-
-4. `ignoreClasses`: (default `[]`)
+1. `ignoreClasses`: (default `[]`)
 By default, the addon will discover all class names in your app and throw a test error if it detects any of them in the heap snapshot. Use this option to ignore specific classes that you expect to leak or plan to fix later. If any of these ignored classes are leaked they will be output as a warning in the test output. Note: framework-level classes such as App are ignored to avoid false positives.
 
-5. `writeSnapshot`: (default `false`)
+1. `remoteDebuggingPort`: (default `9222`)
+Configures which port to connect to the testem Chrome instance. This value must match the `--remote-debugging-port` flag set in your app's `testem.js`
+
+1. `timeout`: (number, default `null`)
+Configures the length of time, in milliseconds, to wait for the memory leak detection test to complete. This value will override any existing timeouts in your test framework. For example, QUnit has a default test timeout of 60s. If you expect memory leak detection to take longer than this it may be useful to specify a longer timeout for the memory leak detection test. 
+*Note*: Currently this timeout is only used with QUnit
+
+1. `writeSnapshot`: (default `false`)
 Set this to `true` to write the heapsnapshot to disk as `Heap.heapsnapshot`. This is helpful for fixing memory leaks, since the file can be uploaded into Chrome DevTool's Memory panel for analysis.
 
 Fixing memory leaks

--- a/packages/ember-cli-memory-leak-detector/README.md
+++ b/packages/ember-cli-memory-leak-detector/README.md
@@ -104,8 +104,9 @@ Configuration
 'ember-cli-memory-leak-detector': {
   enabled: process.env.DETECT_MEMORY_LEAKS || false,
   failTests: false,
-  remoteDebuggingPort: '9222',
   ignoreClasses: ['ExpectedLeakyClass'],
+  remoteDebuggingPort: '9222',
+  timeout: 90000,
   writeSnapshot: true
 }
 
@@ -114,16 +115,20 @@ Configuration
 1. `enabled` (default `true`)
 Set to false to disables memory leak detection. Consider using an environment variable (`process.env.DETECT_MEMORY_LEAKS`) to control when memory leak detection is run.
 
-2. `failTests`: (default `true`)
+1. `failTests`: (default `true`)
 By default when a leak is detected we add a failed test. Set this to `false` to prevent memory leaks from causing your tests to fail, and instead log a console warning.
 
-3. `remoteDebuggingPort`: (default `9222`)
-Configures which port to connect to the testem Chrome instance. This value must match the `--remote-debugging-port` flag set in your app's `testem.js`
-
-4. `ignoreClasses`: (default `[]`)
+1. `ignoreClasses`: (default `[]`)
 By default, the addon will discover all class names in your app and throw a test error if it detects any of them in the heap snapshot. Use this option to ignore specific classes that you expect to leak or plan to fix later. If any of these ignored classes are leaked they will be output as a warning in the test output. Note: framework-level classes such as App are ignored to avoid false positives.
 
-5. `writeSnapshot`: (default `false`)
+1. `remoteDebuggingPort`: (default `9222`)
+Configures which port to connect to the testem Chrome instance. This value must match the `--remote-debugging-port` flag set in your app's `testem.js`
+
+1. `timeout`: (number, default `null`)
+Configures the length of time, in milliseconds, to wait for the memory leak detection test to complete. This value will override any existing timeouts in your test framework. For example, QUnit has a default test timeout of 60s. If you expect memory leak detection to take longer than this it may be useful to specify a longer timeout for the memory leak detection test. 
+*Note*: Currently this timeout is only used with QUnit
+
+1. `writeSnapshot`: (default `false`)
 Set this to `true` to write the heapsnapshot to disk as `Heap.heapsnapshot`. This is helpful for fixing memory leaks, since the file can be uploaded into Chrome DevTool's Memory panel for analysis.
 
 Fixing memory leaks

--- a/packages/ember-cli-memory-leak-detector/config/environment.js
+++ b/packages/ember-cli-memory-leak-detector/config/environment.js
@@ -6,6 +6,7 @@ module.exports = function (/* environment, appConfig */) {
       enabled: true,
       failTests: true,
       remoteDebuggingPort: 9222,
+      timeout: null,
       ignoreClasses: [],
       writeSnapshot: false,
     },

--- a/packages/ember-cli-memory-leak-detector/index.js
+++ b/packages/ember-cli-memory-leak-detector/index.js
@@ -8,13 +8,14 @@ module.exports = {
   name: require("./package").name,
 
   contentFor(type) {
+    let { timeout, failTests } = this.readConfig();
     if (type === "test-body-footer" && this.isEnabled()) {
       const template = fs
         .readFileSync(
           path.join(__dirname, "lib", "templates", "test-body-footer.html")
         )
         .toString();
-      return template;
+      return template.replace('{%TIMEOUT%}', timeout).replace('{%FAIL_TESTS%}', failTests);
     }
 
     return undefined;

--- a/packages/ember-cli-memory-leak-detector/lib/attach-middleware.js
+++ b/packages/ember-cli-memory-leak-detector/lib/attach-middleware.js
@@ -25,7 +25,7 @@ function handleDetectMemoryLinkRequest(addon) {
         config.ignoreClasses.includes(name)
       );
 
-      res.json({ failWithLeakedClasses: config.failTests, leakedClasses, ignoredLeakedClasses });
+      res.json({ leakedClasses, ignoredLeakedClasses });
     } catch (error) {
       addon.ui.writeError({ message: `${addon.name}: ${error}` });
       res.json({ error: `${error}` });

--- a/packages/ember-cli-memory-leak-detector/lib/templates/test-body-footer.html
+++ b/packages/ember-cli-memory-leak-detector/lib/templates/test-body-footer.html
@@ -1,5 +1,8 @@
 <script>
   (function () {
+    const shouldFail = {%FAIL_TESTS%};
+    const timeout = {%TIMEOUT%};
+
     const DETECTION_IS_NOT_POSSIBLE = 'Memory leak detection is currently available only in the Google Chrome browser via Testem';
     const LEAKED_CLASSES = 'The following classes were retained in the heap: \n';
     const LEAKED_IGNORED_CLASSES = 'The following ignored classes were retained in the heap: \n';
@@ -37,7 +40,6 @@
       let endTime = Date.now();
 
       let error = json.error;
-      let shouldFail = json.failWithLeakedClasses;
       let hasLeaks = json.leakedClasses && json.leakedClasses.length;
       let hasIgnoredLeaks = json.ignoredLeakedClasses && json.ignoredLeakedClasses.length;
 
@@ -78,12 +80,14 @@
         });
 
         QUnit.test(TEST_NAME, Object.assign(async function(assert) {
+          if (timeout) {
+            assert.timeout(timeout);
+          }
           let title = encodeURI(document.title);
           let response = await fetch(`/detect_memory_leak?title=${title}`);
           let json = await response.json();
 
           let error = json.error;
-          let shouldFail = json.failWithLeakedClasses;
           let hasLeaks = json.leakedClasses && json.leakedClasses.length;
           let hasIgnoredLeaks = json.ignoredLeakedClasses && json.ignoredLeakedClasses.length;
 


### PR DESCRIPTION
Configuring a timeout allows overriding the global qunit config.testTimeout just for the memory leak detection test.
This is useful in cases where test memory leak detection test takes longer than Qunit's default 60s timeout, and avoids requiring the consuming app to increase their global qunit test timeout.