### PR TITLE
Deprecate configuring `ember-cli-memory-leak-detector` via `config/environment.js`

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,17 +101,18 @@ Configuration
 ------------------------------------------------------------------------------
 
 ```js
-// config/environment.js
+// ember-cli-build.js
 
-'ember-cli-memory-leak-detector': {
-  enabled: process.env.DETECT_MEMORY_LEAKS || false,
-  failTests: false,
-  ignoreClasses: ['ExpectedLeakyClass'],
-  remoteDebuggingPort: '9222',
-  timeout: 90000,
-  writeSnapshot: true
-}
-
+let app = new EmberApp(defaults, {
+  'ember-cli-memory-leak-detector': {
+    enabled: process.env.DETECT_MEMORY_LEAKS || false,
+    failTests: false,
+    ignoreClasses: ['ExpectedLeakyClass'],
+    remoteDebuggingPort: '9222',
+    timeout: 90000,
+    writeSnapshot: true,
+  },
+});
 ```
 
 1. `enabled` (default `true`)

--- a/packages/ember-cli-memory-leak-detector/README.md
+++ b/packages/ember-cli-memory-leak-detector/README.md
@@ -99,17 +99,18 @@ Configuration
 ------------------------------------------------------------------------------
 
 ```js
-// config/environment.js
+// ember-cli-build.js
 
-'ember-cli-memory-leak-detector': {
-  enabled: process.env.DETECT_MEMORY_LEAKS || false,
-  failTests: false,
-  ignoreClasses: ['ExpectedLeakyClass'],
-  remoteDebuggingPort: '9222',
-  timeout: 90000,
-  writeSnapshot: true
-}
-
+let app = new EmberApp(defaults, {
+  'ember-cli-memory-leak-detector': {
+    enabled: process.env.DETECT_MEMORY_LEAKS || false,
+    failTests: false,
+    ignoreClasses: ['ExpectedLeakyClass'],
+    remoteDebuggingPort: '9222',
+    timeout: 90000,
+    writeSnapshot: true,
+  },
+});
 ```
 
 1. `enabled` (default `true`)

--- a/packages/ember-cli-memory-leak-detector/config/environment.js
+++ b/packages/ember-cli-memory-leak-detector/config/environment.js
@@ -1,14 +1,5 @@
 "use strict";
 
 module.exports = function (/* environment, appConfig */) {
-  return {
-    "ember-cli-memory-leak-detector": {
-      enabled: true,
-      failTests: true,
-      remoteDebuggingPort: 9222,
-      timeout: null,
-      ignoreClasses: [],
-      writeSnapshot: false,
-    },
-  };
+  return {};
 };

--- a/packages/ember-cli-memory-leak-detector/ember-cli-build.js
+++ b/packages/ember-cli-memory-leak-detector/ember-cli-build.js
@@ -4,6 +4,11 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
+    'ember-cli-memory-leak-detector': {
+      enabled: !process.env.DISABLE,
+      failTests: !process.env.NOFAIL,
+      ignoreClasses: ['LeakyComponent'],
+    },
     'ember-cli-terser': {
       terser: {
         compress: { keep_classnames: true },

--- a/packages/ember-cli-memory-leak-detector/tests/dummy/config/environment.js
+++ b/packages/ember-cli-memory-leak-detector/tests/dummy/config/environment.js
@@ -21,12 +21,6 @@ module.exports = function(environment) {
       // Here you can pass flags/options to your application instance
       // when it is created
     },
-
-    "ember-cli-memory-leak-detector": {
-      enabled: !process.env.DISABLE,
-      failTests: !process.env.NOFAIL,
-      ignoreClasses: ["LeakyComponent"],
-    },
   };
 
   if (environment === 'development') {

--- a/test-packages/my-app-with-custom-port/config/environment.js
+++ b/test-packages/my-app-with-custom-port/config/environment.js
@@ -17,13 +17,6 @@ module.exports = function (environment) {
       },
     },
 
-    "ember-cli-memory-leak-detector": {
-      enabled: !process.env.DISABLE,
-      failTests: !process.env.NOFAIL,
-      ignoreClasses: ["LeakyComponent"],
-      remoteDebuggingPort: 9223
-    },
-
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created

--- a/test-packages/my-app-with-custom-port/ember-cli-build.js
+++ b/test-packages/my-app-with-custom-port/ember-cli-build.js
@@ -4,7 +4,12 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function (defaults) {
   let app = new EmberApp(defaults, {
-    // Add options here
+    'ember-cli-memory-leak-detector': {
+      enabled: !process.env.DISABLE,
+      failTests: !process.env.NOFAIL,
+      ignoreClasses: ['LeakyComponent'],
+      remoteDebuggingPort: 9223,
+    },
   });
 
   // Use `app.import` to add additional libraries to the generated

--- a/test-packages/my-app/config/environment.js
+++ b/test-packages/my-app/config/environment.js
@@ -17,12 +17,6 @@ module.exports = function (environment) {
       },
     },
 
-    "ember-cli-memory-leak-detector": {
-      enabled: !process.env.DISABLE,
-      failTests: !process.env.NOFAIL,
-      ignoreClasses: ["LeakyComponent"],
-    },
-
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created

--- a/test-packages/my-app/ember-cli-build.js
+++ b/test-packages/my-app/ember-cli-build.js
@@ -4,7 +4,11 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function (defaults) {
   let app = new EmberApp(defaults, {
-    // Add options here
+    'ember-cli-memory-leak-detector': {
+      enabled: !process.env.DISABLE,
+      failTests: !process.env.NOFAIL,
+      ignoreClasses: ['LeakyComponent'],
+    },
   });
 
   // Use `app.import` to add additional libraries to the generated


### PR DESCRIPTION
Since all the work happens at build time, we can ask the user to define the configuration in `ember-cli-build.js` instead. This also prevents the configuration from being added to the app's `meta` tag even when `ember-cli-memory-leak-detector` is disabled.

Closes #39.